### PR TITLE
Mark scaleMode as optional for ILineStyleOptions

### DIFF
--- a/src/SmoothGraphics.ts
+++ b/src/SmoothGraphics.ts
@@ -43,7 +43,7 @@ export interface IFillStyleOptions {
 export interface ILineStyleOptions extends IFillStyleOptions {
     width?: number;
     alignment?: number;
-    scaleMode: LINE_SCALE_MODE;
+    scaleMode?: LINE_SCALE_MODE;
     cap?: LINE_CAP;
     join?: LINE_JOIN;
     miterLimit?: number;


### PR DESCRIPTION
I have got error if not pass scaleMode to linesStyle as ILineStyleOptions

<img width="347" alt="Screenshot 2021-09-25 at 22 33 51" src="https://user-images.githubusercontent.com/6692532/134784058-1ac67d65-ccb1-40a6-a725-fe140d1cca89.png">

Fix this problem mark scaleMode as optional

