### PR TITLE
updated to work on pixi v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "devDependencies": {
         "@microsoft/api-extractor": "7.17.1",
         "@pixi-build-tools/rollup-configurator": "~1.0.11",
-        "@pixi/constants": "^6.0.4",
-        "@pixi/core": "^6.0.4",
-        "@pixi/display": "^6.0.4",
+        "@pixi/constants": "^7.0.0",
+        "@pixi/core": "^7.0.0",
+        "@pixi/display": "^7.0.0",
         "@pixi/eslint-config": "^2.0.1",
-        "@pixi/graphics": "^6.0.4",
-        "@pixi/math": "^6.0.4",
-        "@pixi/utils": "^6.0.4",
+        "@pixi/graphics": "^7.0.0",
+        "@pixi/math": "^7.0.0",
+        "@pixi/utils": "^7.0.0",
         "@typescript-eslint/eslint-plugin": "^4.16.1",
         "@typescript-eslint/parser": "^4.16.1",
         "clean-package": "^1.0.1",
@@ -27,19 +27,19 @@
         "rimraf": "^2.5.3",
         "rollup": "^2.23.1",
         "tslib": "^2.0.1",
-        "typescript": "^3.9.7"
+        "typescript": "4.3.5"
       },
       "engines": {
         "node": ">=14",
         "npm": ">=7"
       },
       "peerDependencies": {
-        "@pixi/constants": "^6.0.4",
-        "@pixi/core": "^6.0.4",
-        "@pixi/display": "^6.0.4",
-        "@pixi/graphics": "^6.0.4",
-        "@pixi/math": "^6.0.4",
-        "@pixi/utils": "^6.0.4"
+        "@pixi/constants": "^7.0.0",
+        "@pixi/core": "^7.0.0",
+        "@pixi/display": "^7.0.0",
+        "@pixi/graphics": "^7.0.0",
+        "@pixi/math": "^7.0.0",
+        "@pixi/utils": "^7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -140,19 +140,6 @@
         "@rushstack/node-core-library": "3.39.0"
       }
     },
-    "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/@microsoft/tsdoc": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.2.tgz",
@@ -242,35 +229,36 @@
       }
     },
     "node_modules/@pixi/constants": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.4.tgz",
-      "integrity": "sha512-khwRMfuHVdFk93L+bf0mmCwtSloYlfBfjdseIAbJL+VSpeMG1S2DzCYlMCPdp4mvDLU9LvkH2U2leZGEIx5j7g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.0.5.tgz",
+      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg==",
       "dev": true
     },
     "node_modules/@pixi/core": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.4.tgz",
-      "integrity": "sha512-r1ceyAz0z3usUs0uj4u2986vVT2tQixGNin2o9FNhPFDXbN5EaoKHLtrjGBt1iylK/EUH/nfL5zq0SGa/loW0A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.0.5.tgz",
+      "integrity": "sha512-+7SgV45t7lw7r8XhtYMv+p0ehc7UPHv9qlMem7Cb/2cZqwxa9Z7TUzQlI9ENb/OsEqURSQ0PJ5ANgEOqQiciiA==",
       "dev": true,
       "dependencies": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/math": "6.0.4",
-        "@pixi/runner": "6.0.4",
-        "@pixi/settings": "6.0.4",
-        "@pixi/ticker": "6.0.4",
-        "@pixi/utils": "6.0.4"
+        "@pixi/constants": "7.0.5",
+        "@pixi/extensions": "7.0.5",
+        "@pixi/math": "7.0.5",
+        "@pixi/runner": "7.0.5",
+        "@pixi/settings": "7.0.5",
+        "@pixi/ticker": "7.0.5",
+        "@pixi/utils": "7.0.5",
+        "@types/offscreencanvas": "^2019.6.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
     },
     "node_modules/@pixi/display": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.4.tgz",
-      "integrity": "sha512-v6hjx5Gm5aIlLQ7xrsZ2lstI1cv/MtbWXJOhU8LXckkrHHUvAuJgml3+0pcHw8YLuOlepZngUuiqy/XjceVk8A==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/math": "6.0.4",
-        "@pixi/settings": "6.0.4",
-        "@pixi/utils": "6.0.4"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.0.5.tgz",
+      "integrity": "sha512-9sXXn7HMFJo5cb4KU3Bdzzhhler9KBuPotHG57gew1MbsMCP32+lvPzqMB1bj6OU0QLjknJxvON77j13CNBh+w==",
+      "dev": true
     },
     "node_modules/@pixi/eslint-config": {
       "version": "2.0.2",
@@ -282,75 +270,61 @@
         "@typescript-eslint/parser": "^4.0.0"
       }
     },
+    "node_modules/@pixi/extensions": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.0.5.tgz",
+      "integrity": "sha512-zCfhMPPZC5dhH0V/GDK1rUEVAT7Ju9K5bIfbd78hbqUZeK7eq8xA8TFEtPE2rdQJesvdDx+qLDv8QhywyR3Y8Q==",
+      "dev": true
+    },
     "node_modules/@pixi/graphics": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.4.tgz",
-      "integrity": "sha512-CybR+DBkGB5llypPeib2A0J13mnPQwlQDqLRhlhXKkYxXQKXlPk5MWA7ZEg+4wKeqUUlrC+k70e5ZFYLC3AgEQ==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/core": "6.0.4",
-        "@pixi/display": "6.0.4",
-        "@pixi/math": "6.0.4",
-        "@pixi/sprite": "6.0.4",
-        "@pixi/utils": "6.0.4"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.0.5.tgz",
+      "integrity": "sha512-I5Y6IpntiEoJB0HOZ7nSw8r3ZHMyyeE8RMCc3Aud6j5B6CtBkpqCHyxOFNmDod2Ymznj/hWBhLl4ee8SJjRdWg==",
+      "dev": true
     },
     "node_modules/@pixi/math": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.4.tgz",
-      "integrity": "sha512-UwZ72CeZ2KsS4IlcEXgNiuD88omPk42Dct74+1G+R2+yPI+XRZq+hGQRTle/BbFYjxh9ccdQVyX9ToGv1XTd6Q==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.0.5.tgz",
+      "integrity": "sha512-v8OCcAL8oK8pf2jtsfHJebTdQ3IA5NI/mdv+Err3F3u4hJHSkDeag9woIBZNfim5ATV/1qriv4b1TT9J+uiL3A==",
       "dev": true
     },
     "node_modules/@pixi/runner": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.4.tgz",
-      "integrity": "sha512-ta6r36r2vC+fPB27URpSacPGQDtbJbdUoeGCJWAEwX+QI4vx4C9NYAcB0bIg8TLXiigCfA6by/RMnJ0dBiemFA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.0.5.tgz",
+      "integrity": "sha512-7Ym6FXwAv+5pM4oPCk4HNiSG7C69W69zZAuoRaz1hvFpu5fi6J4alhDBI1g3u5S+wyQb6ITuwUpNpDLduBuI5w==",
       "dev": true
     },
     "node_modules/@pixi/settings": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.4.tgz",
-      "integrity": "sha512-djiIsmULDwcHWNmEiZKm4zyVopu1NL+fClnbBmtDkGZw7nm37y6dOcdpYawJcxvE4/KLm6pspBiRTnrzdlqW7Q==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.0.5.tgz",
+      "integrity": "sha512-79cP7z4v47gCKecEU24dXL83hYZoXcv7xBG+sF0RQhsRyHoU2niCXukorgsKeMn0Gq/kA+UtWdV0tSCns9xjQQ==",
       "dev": true,
       "dependencies": {
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "node_modules/@pixi/sprite": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.4.tgz",
-      "integrity": "sha512-6yMoHmfFhSRERLM1PUXceq9e6e1UH0YJkLoPVLv6gxMunfk6jPXeO8p9dDS2FQ8ZMSkO/16BKq27HIMKvF6Cvg==",
-      "dev": true,
-      "dependencies": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/core": "6.0.4",
-        "@pixi/display": "6.0.4",
-        "@pixi/math": "6.0.4",
-        "@pixi/settings": "6.0.4",
-        "@pixi/utils": "6.0.4"
+        "@pixi/constants": "7.0.5",
+        "@types/css-font-loading-module": "^0.0.7"
       }
     },
     "node_modules/@pixi/ticker": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.4.tgz",
-      "integrity": "sha512-PkFfPP5vHlgnApLks0Ia0okmFu6KPqBdIyquDqHJAcBdgljedm32KS6K2EH37xelBOzYHScjZ2SQGiiebVfClw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.0.5.tgz",
+      "integrity": "sha512-a/QIvInjKTK5HngkRXjA9EYEuDKkOwEQ4bAZZYx7bjJzFseWULkNsSAdnfqjny+BOLIKhF7u2Hf4n+ef1H2xMg==",
       "dev": true,
       "dependencies": {
-        "@pixi/settings": "6.0.4"
+        "@pixi/extensions": "7.0.5",
+        "@pixi/settings": "7.0.5"
       }
     },
     "node_modules/@pixi/utils": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.4.tgz",
-      "integrity": "sha512-35JTWsAJ8Va0vvtUSQvyOr3kGedGKVuJnHDO89B8C8tSFtMpJYrR44vp1b1p1vOjNak+ulGehZc8LzlCqymViQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.0.5.tgz",
+      "integrity": "sha512-aFweyXTC2dlsyVQNQarsPQXIuuQDIPSV5WI4unU3VpQ+SaKmH3LTHm4+75JgOweGwRclUw4c/kEYf92RmQBmHg==",
       "dev": true,
       "dependencies": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/settings": "6.0.4",
+        "@pixi/constants": "7.0.5",
+        "@pixi/settings": "7.0.5",
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
-        "eventemitter3": "^3.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
         "url": "^0.11.0"
       }
     },
@@ -450,6 +424,12 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "dev": true
+    },
     "node_modules/@types/earcut": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
@@ -472,6 +452,12 @@
       "version": "10.17.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
       "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
+      "dev": true
+    },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
       "dev": true
     },
     "node_modules/@types/resolve": {
@@ -940,9 +926,9 @@
       }
     },
     "node_modules/earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -1324,9 +1310,9 @@
       }
     },
     "node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "node_modules/fast-deep-equal": {
@@ -1819,12 +1805,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "node_modules/ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
       "dev": true
     },
     "node_modules/jest-worker": {
@@ -2391,13 +2371,14 @@
     "node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
     "node_modules/querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
       "dev": true,
       "engines": {
         "node": ">=0.4.x"
@@ -3085,9 +3066,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3139,7 +3120,7 @@
     "node_modules/url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
       "dependencies": {
         "punycode": "1.3.2",
@@ -3308,14 +3289,6 @@
         "semver": "~7.3.0",
         "source-map": "~0.6.1",
         "typescript": "~4.3.2"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-          "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-          "dev": true
-        }
       }
     },
     "@microsoft/api-extractor-model": {
@@ -3408,35 +3381,32 @@
       }
     },
     "@pixi/constants": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-6.0.4.tgz",
-      "integrity": "sha512-khwRMfuHVdFk93L+bf0mmCwtSloYlfBfjdseIAbJL+VSpeMG1S2DzCYlMCPdp4mvDLU9LvkH2U2leZGEIx5j7g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.0.5.tgz",
+      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg==",
       "dev": true
     },
     "@pixi/core": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-6.0.4.tgz",
-      "integrity": "sha512-r1ceyAz0z3usUs0uj4u2986vVT2tQixGNin2o9FNhPFDXbN5EaoKHLtrjGBt1iylK/EUH/nfL5zq0SGa/loW0A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.0.5.tgz",
+      "integrity": "sha512-+7SgV45t7lw7r8XhtYMv+p0ehc7UPHv9qlMem7Cb/2cZqwxa9Z7TUzQlI9ENb/OsEqURSQ0PJ5ANgEOqQiciiA==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/math": "6.0.4",
-        "@pixi/runner": "6.0.4",
-        "@pixi/settings": "6.0.4",
-        "@pixi/ticker": "6.0.4",
-        "@pixi/utils": "6.0.4"
+        "@pixi/constants": "7.0.5",
+        "@pixi/extensions": "7.0.5",
+        "@pixi/math": "7.0.5",
+        "@pixi/runner": "7.0.5",
+        "@pixi/settings": "7.0.5",
+        "@pixi/ticker": "7.0.5",
+        "@pixi/utils": "7.0.5",
+        "@types/offscreencanvas": "^2019.6.4"
       }
     },
     "@pixi/display": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-6.0.4.tgz",
-      "integrity": "sha512-v6hjx5Gm5aIlLQ7xrsZ2lstI1cv/MtbWXJOhU8LXckkrHHUvAuJgml3+0pcHw8YLuOlepZngUuiqy/XjceVk8A==",
-      "dev": true,
-      "requires": {
-        "@pixi/math": "6.0.4",
-        "@pixi/settings": "6.0.4",
-        "@pixi/utils": "6.0.4"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.0.5.tgz",
+      "integrity": "sha512-9sXXn7HMFJo5cb4KU3Bdzzhhler9KBuPotHG57gew1MbsMCP32+lvPzqMB1bj6OU0QLjknJxvON77j13CNBh+w==",
+      "dev": true
     },
     "@pixi/eslint-config": {
       "version": "2.0.2",
@@ -3448,75 +3418,61 @@
         "@typescript-eslint/parser": "^4.0.0"
       }
     },
+    "@pixi/extensions": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.0.5.tgz",
+      "integrity": "sha512-zCfhMPPZC5dhH0V/GDK1rUEVAT7Ju9K5bIfbd78hbqUZeK7eq8xA8TFEtPE2rdQJesvdDx+qLDv8QhywyR3Y8Q==",
+      "dev": true
+    },
     "@pixi/graphics": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-6.0.4.tgz",
-      "integrity": "sha512-CybR+DBkGB5llypPeib2A0J13mnPQwlQDqLRhlhXKkYxXQKXlPk5MWA7ZEg+4wKeqUUlrC+k70e5ZFYLC3AgEQ==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/core": "6.0.4",
-        "@pixi/display": "6.0.4",
-        "@pixi/math": "6.0.4",
-        "@pixi/sprite": "6.0.4",
-        "@pixi/utils": "6.0.4"
-      }
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.0.5.tgz",
+      "integrity": "sha512-I5Y6IpntiEoJB0HOZ7nSw8r3ZHMyyeE8RMCc3Aud6j5B6CtBkpqCHyxOFNmDod2Ymznj/hWBhLl4ee8SJjRdWg==",
+      "dev": true
     },
     "@pixi/math": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-6.0.4.tgz",
-      "integrity": "sha512-UwZ72CeZ2KsS4IlcEXgNiuD88omPk42Dct74+1G+R2+yPI+XRZq+hGQRTle/BbFYjxh9ccdQVyX9ToGv1XTd6Q==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.0.5.tgz",
+      "integrity": "sha512-v8OCcAL8oK8pf2jtsfHJebTdQ3IA5NI/mdv+Err3F3u4hJHSkDeag9woIBZNfim5ATV/1qriv4b1TT9J+uiL3A==",
       "dev": true
     },
     "@pixi/runner": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-6.0.4.tgz",
-      "integrity": "sha512-ta6r36r2vC+fPB27URpSacPGQDtbJbdUoeGCJWAEwX+QI4vx4C9NYAcB0bIg8TLXiigCfA6by/RMnJ0dBiemFA==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.0.5.tgz",
+      "integrity": "sha512-7Ym6FXwAv+5pM4oPCk4HNiSG7C69W69zZAuoRaz1hvFpu5fi6J4alhDBI1g3u5S+wyQb6ITuwUpNpDLduBuI5w==",
       "dev": true
     },
     "@pixi/settings": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-6.0.4.tgz",
-      "integrity": "sha512-djiIsmULDwcHWNmEiZKm4zyVopu1NL+fClnbBmtDkGZw7nm37y6dOcdpYawJcxvE4/KLm6pspBiRTnrzdlqW7Q==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.0.5.tgz",
+      "integrity": "sha512-79cP7z4v47gCKecEU24dXL83hYZoXcv7xBG+sF0RQhsRyHoU2niCXukorgsKeMn0Gq/kA+UtWdV0tSCns9xjQQ==",
       "dev": true,
       "requires": {
-        "ismobilejs": "^1.1.0"
-      }
-    },
-    "@pixi/sprite": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-6.0.4.tgz",
-      "integrity": "sha512-6yMoHmfFhSRERLM1PUXceq9e6e1UH0YJkLoPVLv6gxMunfk6jPXeO8p9dDS2FQ8ZMSkO/16BKq27HIMKvF6Cvg==",
-      "dev": true,
-      "requires": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/core": "6.0.4",
-        "@pixi/display": "6.0.4",
-        "@pixi/math": "6.0.4",
-        "@pixi/settings": "6.0.4",
-        "@pixi/utils": "6.0.4"
+        "@pixi/constants": "7.0.5",
+        "@types/css-font-loading-module": "^0.0.7"
       }
     },
     "@pixi/ticker": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-6.0.4.tgz",
-      "integrity": "sha512-PkFfPP5vHlgnApLks0Ia0okmFu6KPqBdIyquDqHJAcBdgljedm32KS6K2EH37xelBOzYHScjZ2SQGiiebVfClw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.0.5.tgz",
+      "integrity": "sha512-a/QIvInjKTK5HngkRXjA9EYEuDKkOwEQ4bAZZYx7bjJzFseWULkNsSAdnfqjny+BOLIKhF7u2Hf4n+ef1H2xMg==",
       "dev": true,
       "requires": {
-        "@pixi/settings": "6.0.4"
+        "@pixi/extensions": "7.0.5",
+        "@pixi/settings": "7.0.5"
       }
     },
     "@pixi/utils": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-6.0.4.tgz",
-      "integrity": "sha512-35JTWsAJ8Va0vvtUSQvyOr3kGedGKVuJnHDO89B8C8tSFtMpJYrR44vp1b1p1vOjNak+ulGehZc8LzlCqymViQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.0.5.tgz",
+      "integrity": "sha512-aFweyXTC2dlsyVQNQarsPQXIuuQDIPSV5WI4unU3VpQ+SaKmH3LTHm4+75JgOweGwRclUw4c/kEYf92RmQBmHg==",
       "dev": true,
       "requires": {
-        "@pixi/constants": "6.0.4",
-        "@pixi/settings": "6.0.4",
+        "@pixi/constants": "7.0.5",
+        "@pixi/settings": "7.0.5",
         "@types/earcut": "^2.1.0",
-        "earcut": "^2.2.2",
-        "eventemitter3": "^3.1.0",
+        "earcut": "^2.2.4",
+        "eventemitter3": "^4.0.0",
         "url": "^0.11.0"
       }
     },
@@ -3609,6 +3565,12 @@
       "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
       "dev": true
     },
+    "@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "dev": true
+    },
     "@types/earcut": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.1.tgz",
@@ -3631,6 +3593,12 @@
       "version": "10.17.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
       "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
+      "dev": true
+    },
+    "@types/offscreencanvas": {
+      "version": "2019.7.0",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.0.tgz",
+      "integrity": "sha512-PGcyveRIpL1XIqK8eBsmRBt76eFgtzuPiSTyKHZxnGemp2yzGzWpjYKAfK3wIMiU7eH+851yEpiuP8JZerTmWg==",
       "dev": true
     },
     "@types/resolve": {
@@ -4002,9 +3970,9 @@
       }
     },
     "earcut": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.2.tgz",
-      "integrity": "sha512-eZoZPPJcUHnfRZ0PjLvx2qBordSiO8ofC3vt+qACLM95u+4DovnbYNpQtJh0DNsWj8RnxrQytD4WA8gj5cRIaQ==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -4311,9 +4279,9 @@
       "dev": true
     },
     "eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "dev": true
     },
     "fast-deep-equal": {
@@ -4711,12 +4679,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "ismobilejs": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
       "dev": true
     },
     "jest-worker": {
@@ -5178,13 +5140,13 @@
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+      "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==",
       "dev": true
     },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+      "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==",
       "dev": true
     },
     "queue-microtask": {
@@ -5764,9 +5726,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.10",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
-      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
+      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
       "dev": true
     },
     "unbox-primitive": {
@@ -5807,7 +5769,7 @@
     "url": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
-      "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+      "integrity": "sha512-kbailJa29QrtXnxgq+DdCEGlbTeYM2eJUxsz6vjZavrCYPMIFHMKQmSKYAIuUK2i7hgPm28a8piX5NTUtM/LKQ==",
       "dev": true,
       "requires": {
         "punycode": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -72,23 +72,23 @@
     "README.md"
   ],
   "peerDependencies": {
-    "@pixi/constants": "^6.0.4",
-    "@pixi/core": "^6.0.4",
-    "@pixi/display": "^6.0.4",
-    "@pixi/graphics": "^6.0.4",
-    "@pixi/math": "^6.0.4",
-    "@pixi/utils": "^6.0.4"
+    "@pixi/constants": "^7.0.0",
+    "@pixi/core": "^7.0.0",
+    "@pixi/display": "^7.0.0",
+    "@pixi/graphics": "^7.0.0",
+    "@pixi/math": "^7.0.0",
+    "@pixi/utils": "^7.0.0"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "7.17.1",
     "@pixi-build-tools/rollup-configurator": "~1.0.11",
-    "@pixi/constants": "^6.0.4",
-    "@pixi/core": "^6.0.4",
-    "@pixi/display": "^6.0.4",
+    "@pixi/constants": "^7.0.0",
+    "@pixi/core": "^7.0.0",
+    "@pixi/display": "^7.0.0",
     "@pixi/eslint-config": "^2.0.1",
-    "@pixi/graphics": "^6.0.4",
-    "@pixi/math": "^6.0.4",
-    "@pixi/utils": "^6.0.4",
+    "@pixi/graphics": "^7.0.0",
+    "@pixi/math": "^7.0.0",
+    "@pixi/utils": "^7.0.0",
     "@typescript-eslint/eslint-plugin": "^4.16.1",
     "@typescript-eslint/parser": "^4.16.1",
     "clean-package": "^1.0.1",
@@ -98,6 +98,6 @@
     "rimraf": "^2.5.3",
     "rollup": "^2.23.1",
     "tslib": "^2.0.1",
-    "typescript": "^3.9.7"
+    "typescript": "4.3.5"
   }
 }

--- a/src/SmoothGraphics.ts
+++ b/src/SmoothGraphics.ts
@@ -14,7 +14,7 @@ import { Texture, State, Renderer, Shader } from '@pixi/core';
 import { graphicsUtils, LINE_JOIN, LINE_CAP, Graphics } from '@pixi/graphics';
 import { hex2rgb } from '@pixi/utils';
 import { SmoothGraphicsGeometry } from './SmoothGraphicsGeometry';
-import { BLEND_MODES, DRAW_MODES } from '@pixi/constants';
+import { BLEND_MODES, DRAW_MODES, MSAA_QUALITY } from '@pixi/constants';
 import { Container } from '@pixi/display';
 
 import type { IShape, IPointData } from '@pixi/math';
@@ -699,9 +699,11 @@ export class SmoothGraphics extends Container
 
             uniforms.resolution *= scale;
         }
-        const gl = (renderer.context as any).gl;
 
-        uniforms.expand = (gl.getContextAttributes().antialias ? 2 : 1) / uniforms.resolution;
+        const multisample = renderer.renderTexture.current
+            ? renderer.renderTexture.current.multisample : renderer.multisample;
+
+        uniforms.expand = (multisample !== MSAA_QUALITY.NONE ? 2 : 1) / uniforms.resolution;
 
         // the first draw call, we can set the uniforms of the shader directly here.
 

--- a/src/SmoothGraphics.ts
+++ b/src/SmoothGraphics.ts
@@ -707,8 +707,9 @@ export class SmoothGraphics extends Container
 
             uniforms.resolution *= scale;
         }
+        const gl = (renderer.context as any).gl;
 
-        uniforms.expand = (renderer.options.antialias ? 2 : 1) / uniforms.resolution;
+        uniforms.expand = (gl.getContextAttributes().antialias ? 2 : 1) / uniforms.resolution;
 
         // the first draw call, we can set the uniforms of the shader directly here.
 

--- a/src/SmoothGraphics.ts
+++ b/src/SmoothGraphics.ts
@@ -52,14 +52,6 @@ export interface ILineStyleOptions extends IFillStyleOptions {
 
 export class SmoothGraphics extends Container
 {
-    public static get nextRoundedRectBehavior(): boolean {
-        return (UnsmoothGraphics as any).nextRoundedRectBehavior;
-    }
-
-    public static set nextRoundedRectBehavior(value: boolean) {
-        (UnsmoothGraphics as any).nextRoundedRectBehavior = value;
-    }
-
     static _TEMP_POINT = new Point();
 
     public shader: Shader;

--- a/src/shapes/RoundedRectangleBuilder.ts
+++ b/src/shapes/RoundedRectangleBuilder.ts
@@ -1,124 +1,15 @@
 import type { IShapeBuilder } from '../core/IShapeBuilder';
-import { SmoothGraphicsData } from '../core/SmoothGraphicsData';
-import { BuildData } from '../core/BuildData';
-import { Graphics } from '@pixi/graphics';
-import { RoundedRectangle } from '@pixi/math';
+import type { SmoothGraphicsData } from '../core/SmoothGraphicsData';
+import type { BuildData } from '../core/BuildData';
 import { CircleBuilder } from './CircleBuilder';
-
-function getPt(n1: number, n2: number, perc: number): number
-{
-    const diff = n2 - n1;
-
-    return n1 + (diff * perc);
-}
-
-function quadraticBezierCurve(
-    fromX: number, fromY: number,
-    cpX: number, cpY: number,
-    toX: number, toY: number,
-    out: Array<number> = [],
-    eps = 0.001): Array<number>
-{
-    const n = 20;
-    const points = out;
-
-    let xa = 0;
-    let ya = 0;
-    let xb = 0;
-    let yb = 0;
-    let x = 0;
-    let y = 0;
-
-    for (let i = 0, j = 0; i <= n; ++i)
-    {
-        j = i / n;
-
-        // The Green Line
-        xa = getPt(fromX, cpX, j);
-        ya = getPt(fromY, cpY, j);
-        xb = getPt(cpX, toX, j);
-        yb = getPt(cpY, toY, j);
-
-        // The Black Dot
-        x = getPt(xa, xb, j);
-        y = getPt(ya, yb, j);
-
-        // Handle case when first curve points overlaps and earcut fails to triangulate
-        if (i === 0
-            && Math.abs(x - points[points.length - 2]) < eps
-            && Math.abs(y - points[points.length - 1]) < eps)
-        {
-            continue;
-        }
-
-        points.push(x, y);
-    }
-
-    return points;
-}
 
 export class RoundedRectangleBuilder implements IShapeBuilder
 {
     _circleBuilder = new CircleBuilder();
 
-    path(graphicsData: SmoothGraphicsData, _target: BuildData)
+    path(graphicsData: SmoothGraphicsData, target: BuildData)
     {
-        if ((Graphics as any).nextRoundedRectBehavior)
-        {
-            this._circleBuilder.path(graphicsData, _target);
-
-            return;
-        }
-
-        const rrectData = graphicsData.shape as RoundedRectangle;
-        const { points } = graphicsData;
-        const x = rrectData.x;
-        const y = rrectData.y;
-        const width = rrectData.width;
-        const height = rrectData.height;
-
-        // Don't allow negative radius or greater than half the smallest width
-        const radius = Math.max(0, Math.min(rrectData.radius, Math.min(width, height) / 2));
-
-        points.length = 0;
-
-        // No radius, do a simple rectangle
-        if (!radius)
-        {
-            points.push(x, y,
-                x + width, y,
-                x + width, y + height,
-                x, y + height);
-        }
-        else
-        {
-            const eps = _target.closePointEps;
-
-            quadraticBezierCurve(x, y + radius,
-                x, y,
-                x + radius, y,
-                points, eps);
-            quadraticBezierCurve(x + width - radius,
-                y, x + width, y,
-                x + width, y + radius,
-                points, eps);
-            quadraticBezierCurve(x + width, y + height - radius,
-                x + width, y + height,
-                x + width - radius, y + height,
-                points, eps);
-            quadraticBezierCurve(x + radius, y + height,
-                x, y + height,
-                x, y + height - radius,
-                points, eps);
-
-            if (points.length >= 4
-                && Math.abs(points[0] - points[points.length - 2]) < eps
-                && Math.abs(points[1] - points[points.length - 1]) < eps)
-            {
-                points.pop();
-                points.pop();
-            }
-        }
+        this._circleBuilder.path(graphicsData, target);
     }
 
     line(graphicsData: SmoothGraphicsData, target: BuildData): void


### PR DESCRIPTION
updated to work on v7

- added compatibility with pixi v7
  - small hack to get the antialias of the gl context
  - updated deps to pixi v7
- updated typescript version to last working version for building libs
- broken compatibility with pixi v6
  - We will need some different version number or something
  - When can this be official graphics?

texted on pixi.js bundle v7