### PR TITLE
fix: removed @pixi/constants from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "npm": ">=8"
       },
       "peerDependencies": {
-        "@pixi/constants": "^7.0.0",
         "@pixi/core": "^7.0.0",
         "@pixi/display": "^7.0.0",
         "@pixi/graphics": "^7.0.0"
@@ -2172,7 +2171,8 @@
     "node_modules/@pixi/constants": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.0.5.tgz",
-      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg=="
+      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg==",
+      "dev": true
     },
     "node_modules/@pixi/core": {
       "version": "7.0.5",
@@ -15664,7 +15664,8 @@
     "@pixi/constants": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.0.5.tgz",
-      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg=="
+      "integrity": "sha512-4u5UqLo+8uuUon2EBIjSxUo80r7eUr1gWpFAg2B9ziRJePl5Q75azYX+77uVp5cFnloYIcSuNyjtJFdQ/umDgg==",
+      "dev": true
     },
     "@pixi/core": {
       "version": "7.0.5",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     }
   },
   "extensionConfig": {
-    "lint": ["src"],
+    "lint": [
+      "src"
+    ],
     "namespace": "PIXI.smooth",
     "docsName": "PixiJS Smooth Graphics",
     "docsCopyright": "Copyright &copy; 2015 - 2022 Ivan Popelyshev",
@@ -58,7 +60,6 @@
     "lib/"
   ],
   "peerDependencies": {
-    "@pixi/constants": "^7.0.0",
     "@pixi/core": "^7.0.0",
     "@pixi/display": "^7.0.0",
     "@pixi/graphics": "^7.0.0"


### PR DESCRIPTION
@pixi/core now bundles a lot of other @pixi/* packages so by requiring a peerdep to @pixi/constants we force the user to double include that package

Plugins now **can not** have any of these as a dependency / peerDependency since these are bundled inside `@pixi/core`. If a package needs something from this, then you should depend on `@pixi/core`

```
    "@pixi/constants"
    "@pixi/extensions"
    "@pixi/math"
    "@pixi/runner"
    "@pixi/settings"
    "@pixi/ticker"
    "@pixi/utils"
```